### PR TITLE
Add drag-to-resize handle to top-left of notes box.

### DIFF
--- a/awbw-notes.user.js
+++ b/awbw-notes.user.js
@@ -1,20 +1,27 @@
 // ==UserScript==
 // @name         AWBW Notepad
 // @namespace    https://github.com/MikeFHay/
-// @version      0.2
+// @version      0.3
 // @description  Adds per-game notes to Advance Wars By Web
 // @author       https://github.com/MikeFHay
 // @match        https://awbw.amarriner.com/2030.php?games_id=*
 // @icon         https://www.google.com/s2/favicons?domain=tampermonkey.net
+// @require      https://code.jquery.com/ui/1.12.1/jquery-ui.min.js
 // @grant        GM_addStyle
 // ==/UserScript==
 
 (function() {
+    $("head").append (
+        '<link href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css" '
+      + 'rel="stylesheet" type="text/css">'
+    );
+
     'use strict';
     const key = "notes_" + gameId;
     var text = localStorage.getItem(key) || "";
 
     var textBox = document.createElement("textarea");
+    textBox.setAttribute("id", "notesTextArea");
     textBox.setAttribute("class", "notesClosable");
     textBox.setAttribute("style", "position:inline;width:200px;height:100px;");
     textBox.value = text;
@@ -24,7 +31,7 @@
     closeButton.setAttribute("id", "notesClose");
 
     var divBox = document.createElement("div");
-    divBox.innerHTML = "<header class='notesClosable'>Notes:</header>";
+    divBox.innerHTML = "<span class='notesAbs'>&#8689</span><header class='notesClosable'>Notes:</header>";
     divBox.setAttribute("id", "playerNotesArea");
     divBox.prepend(closeButton);
     divBox.appendChild(textBox);
@@ -40,20 +47,20 @@
         event.stopPropagation();
     });
 
+    $("#notesTextArea").resizable({
+        handles: "nw"
+    });
+    $("#notesTextArea").parent().addClass("notesClosable"); //Make the 'parent' resizing div disappear on click too.
+    $("#notesTextArea").parent()[0].style.position = null; //HACK: Move the resizable() handle to the top-left, ignoring header.
+
     var isOpen = true;
     closeButton.addEventListener("click", function(event) {
         if(isOpen) {
-            var closableThings = document.getElementsByClassName("notesClosable");
-            for (var i = 0; i < closableThings.length; i++) {
-                closableThings[i].style.display = "none";
-            }
+            $(".notesClosable").css("display", "none");
             closeButton.innerHTML = "&#9650;"
             isOpen = false;
         } else {
-            var closableThings = document.getElementsByClassName("notesClosable");
-            for (var i = 0; i < closableThings.length; i++) {
-                closableThings[i].style.display = "block";
-            }
+            $(".notesClosable").css("display", "block");
             closeButton.innerHTML = "&#9660;"
             isOpen = true;
         }
@@ -61,23 +68,34 @@
 
     GM_addStyle(`
         #playerNotesArea {
-           position:fixed;
+           position: fixed;
            bottom: 0px;
            right: 0px;
            border: 1px solid black;
            background-color: white;
+           z-index: 99;
         }
 
         #notesClose {
-            position:absolute;
-            right:0px;
+            position: absolute;
+            right: 0px;
             top: -20px;
             border: 1px solid black;
             background-color: white;
         }
 
+        #notesTextArea {
+            resize: none;
+        }
+
         .notesClosable {
             display: block;
+        }
+        
+        .notesAbs {
+            position: absolute;
+            top: -5px;
+            left: -1px;
         }
     `);
 })();

--- a/awbw-notes.user.js
+++ b/awbw-notes.user.js
@@ -19,11 +19,14 @@
     'use strict';
     const key = "notes_" + gameId;
     var text = localStorage.getItem(key) || "";
+    
+    var initialWidth = localStorage.getItem("notes_size_w") || 200;
+    var initialHeight = localStorage.getItem("notes_size_h") || 100;
 
     var textBox = document.createElement("textarea");
     textBox.setAttribute("id", "notesTextArea");
     textBox.setAttribute("class", "notesClosable");
-    textBox.setAttribute("style", "position:inline;width:200px;height:100px;");
+    textBox.setAttribute("style", "position:inline;width:" + initialWidth + "px;height:" + initialHeight + "px;");
     textBox.value = text;
 
     var closeButton = document.createElement("div");
@@ -48,7 +51,11 @@
     });
 
     $("#notesTextArea").resizable({
-        handles: "nw"
+        handles: "nw",
+        stop: function(event, ui) {
+            localStorage.setItem("notes_size_w", ui.size.width);
+            localStorage.setItem("notes_size_h", ui.size.height);
+        }
     });
     $("#notesTextArea").parent().addClass("notesClosable"); //Make the 'parent' resizing div disappear on click too.
     $("#notesTextArea").parent()[0].style.position = null; //HACK: Move the resizable() handle to the top-left, ignoring header.


### PR DESCRIPTION
Dragging the top-left of the notes box changes its size, but keeps it locked to the bottom-right of the screen.
Keeps size after closing and re-opening box. Keeps size between games/on reload (as of 2021-07-27).
Added Z-Index so the notes box stays above the map.

### Dev Notes
* This adds JQuery UI and its CSS. The CSS is added by a slightly hacky-looking addition to `<head>`, but I couldn't get `@resource` working correctly.
* I've JQuery-ified the "loops" that happened on close and re-open.


### Testing Done
Works locally, FF90.0.2 . Tried on a couple different windows sizes, but not exhaustively.

Would appreciate some testing on your end too before we merge this.

![wip-awbw](https://user-images.githubusercontent.com/2098085/127065859-71a1af4f-4821-4837-9771-bcd3baf983b0.gif)
